### PR TITLE
Create length translation service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import ContentSearch from "./services/content-search";
 import ContentPost from "./services/content-post";
 import AnnounceStream from "./services/announce-stream";
 import TranslateTemperature from "./services/translate-temperature";
+import TranslateLength from "./services/translate-length";
 import WarnDeprecatedCommands from "./services/warn-deprecated-commands";
 import DBTest from "./services/db-test";
 import Shunt from "./services/shunt";
@@ -56,6 +57,7 @@ const services = [
   StreamHost,
   ThreadDigest,
   TranslateTemperature,
+  TranslateLength,
   WarnDeprecatedCommands,
   CreateEventForumPost,
   CreateEventFromThread,

--- a/src/services/translate-length/Length.ts
+++ b/src/services/translate-length/Length.ts
@@ -1,0 +1,49 @@
+export type Unit = "mm" | "cm" | "m" | "km" | "in" | "ft" | "mi";
+
+export class Length {
+  public millimeters: number = 0;
+  public centimeters: number = 0;
+  public meters: number = 0;
+  public kilometers: number = 0;
+  public inches: number = 0;
+  public feet: number = 0;
+  public miles: number = 0;
+
+  constructor(value: number, unit: Unit) {
+    // Convert to base unit (meters) first, then to all other units
+    const meters = this.toMeters(value, unit);
+    
+    this.meters = this.round(meters);
+    this.millimeters = this.round(meters * 1000);
+    this.centimeters = this.round(meters * 100);
+    this.kilometers = this.round(meters / 1000);
+    this.inches = this.round(meters * 39.3701);
+    this.feet = this.round(meters * 3.28084);
+    this.miles = this.round(meters / 1609.344);
+  }
+
+  private round(value: number) {
+    return Math.round(value * 100) / 100;
+  }
+
+  private toMeters(value: number, unit: Unit): number {
+    switch (unit) {
+      case "mm":
+        return value / 1000;
+      case "cm":
+        return value / 100;
+      case "m":
+        return value;
+      case "km":
+        return value * 1000;
+      case "in":
+        return value / 39.3701;
+      case "ft":
+        return value / 3.28084;
+      case "mi":
+        return value * 1609.344;
+      default:
+        return value;
+    }
+  }
+}

--- a/src/services/translate-length/index.ts
+++ b/src/services/translate-length/index.ts
@@ -1,0 +1,102 @@
+import { EmbedBuilder, Message } from "discord.js";
+import { Providers } from "../../providers";
+import { Length, Unit } from "./Length";
+
+const regex = new RegExp(
+  /(?<=^|[\s(=])(?<sign>[-+]?)(?<length1>(?:0|[1-9](?:\d*|\d{0,2}(?:,\d{3})*))?(?:\.\d*\d)?)-?(?<length2>(?:0|[1-9](?:\d*|\d{0,2}(?:,\d{3})*))?(?:\.\d*\d)?)?(?<=\d)\s?(?<unit>mm|cm|m|km|in|ft|mi|millimeters?|centimeters?|meters?|kilometers?|inches?|feet?|miles?)\b/gi
+);
+
+const numConvert = (str: string) => Number(str.replace(/,/g, ""));
+
+const normalizeUnit = (unit: string): Unit => {
+  const lowerUnit = unit.toLowerCase();
+  if (lowerUnit.startsWith("mm") || lowerUnit === "millimeters" || lowerUnit === "millimeter") return "mm";
+  if (lowerUnit.startsWith("cm") || lowerUnit === "centimeters" || lowerUnit === "centimeter") return "cm";
+  if (lowerUnit.startsWith("m") && !lowerUnit.startsWith("mm") && !lowerUnit.startsWith("mi") && lowerUnit !== "millimeters" && lowerUnit !== "miles") return "m";
+  if (lowerUnit.startsWith("km") || lowerUnit === "kilometers" || lowerUnit === "kilometer") return "km";
+  if (lowerUnit.startsWith("in") || lowerUnit === "inches" || lowerUnit === "inch") return "in";
+  if (lowerUnit.startsWith("ft") || lowerUnit === "feet" || lowerUnit === "foot") return "ft";
+  if (lowerUnit.startsWith("mi") || lowerUnit === "miles" || lowerUnit === "mile") return "mi";
+  return "m"; // default fallback
+};
+
+export const findLengthsToConvert = (message: Message) => {
+  const matches = message.content.matchAll(regex);
+  const lengthsToConvert: Length[] = [];
+  const dupChecker: string[] = []; // stores simple values to check for duplicates
+
+  for (const match of matches) {
+    const { sign, length1, length2, unit } = match.groups;
+    const formattedUnit = normalizeUnit(unit);
+
+    const simpleValue1 = `${sign}${length1}${unit}`;
+
+    // checks if value is a duplicate
+    if (length1 && !dupChecker.includes(simpleValue1)) {
+      dupChecker.push(simpleValue1);
+
+      const value = sign ? -numConvert(length1) : numConvert(length1);
+      lengthsToConvert.push(new Length(value, formattedUnit));
+    }
+
+    const simpleValue2 = `${length2}${unit}`;
+
+    if (length2 && !dupChecker.includes(simpleValue2)) {
+      dupChecker.push(simpleValue2);
+
+      const value = numConvert(length2);
+      lengthsToConvert.push(new Length(value, formattedUnit));
+    }
+  }
+
+  return lengthsToConvert;
+};
+
+export const createLengthConversionEmbed = (lengths: Length[]) => {
+  const description = lengths
+    .map((length) => {
+      // Determine which units to show based on the original unit
+      let metricDisplay = "";
+      let imperialDisplay = "";
+
+      // For small units (mm, cm), show mm, cm, in
+      if (length.millimeters < 1000 && length.centimeters < 100) {
+        metricDisplay = `:straight_ruler: ${length.millimeters} mm / ${length.centimeters} cm`;
+        imperialDisplay = `:flag_us: ${length.inches} in`;
+      }
+      // For medium units (m), show m, ft
+      else if (length.meters < 1000) {
+        metricDisplay = `:straight_ruler: ${length.meters} m`;
+        imperialDisplay = `:flag_us: ${length.feet} ft`;
+      }
+      // For large units (km), show km, mi
+      else {
+        metricDisplay = `:straight_ruler: ${length.kilometers} km`;
+        imperialDisplay = `:flag_us: ${length.miles} mi`;
+      }
+
+      return `${metricDisplay} ${imperialDisplay}`;
+    })
+    .join("\n");
+
+  const embed = new EmbedBuilder({
+    title: "Length Converter",
+    description,
+  });
+
+  return embed;
+};
+
+export default function TranslateLength({ helperBot }: Providers) {
+  helperBot.on("messageCreate", async (message) => {
+    const lengthsToConvert = findLengthsToConvert(message);
+    if (lengthsToConvert.length) {
+      const embeds = [createLengthConversionEmbed(lengthsToConvert)];
+      try {
+        await message.channel.send({ embeds });
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  });
+}

--- a/src/services/translate-temperature/index.ts
+++ b/src/services/translate-temperature/index.ts
@@ -6,7 +6,7 @@ const regex = new RegExp(
   /(?<=^|[\s(=])(?<sign>[-+]?)(?<temp1>(?:0|[1-9](?:\d*|\d{0,2}(?:,\d{3})*))?(?:\.\d*\d)?)-?(?<temp2>(?:0|[1-9](?:\d*|\d{0,2}(?:,\d{3})*))?(?:\.\d*\d)?)?(?<=\d)\s?°?\s?(?<unit>C|celsius|F|fahrenheit|kelvin)\b/gi
 );
 
-const numConvert = (str: string) => Number(str.replaceAll(",", ""));
+const numConvert = (str: string) => Number(str.replace(/,/g, ""));
 
 export const findTempsToConvert = (message: Message) => {
   const matches = message.content.matchAll(regex);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "sourceMap": true,
     "outDir": "dist",
-    "lib": ["es2021.string"],
+    "lib": ["es2021", "es2021.string"],
     "downlevelIteration": true,
     "skipLibCheck": true,
     "esModuleInterop": true


### PR DESCRIPTION
Add `translate-length` service to convert length units in Discord messages, mirroring the `translate-temperature` service.

The new service detects various metric and imperial length units (e.g., m, km, in, ft) and provides conversions in a Discord embed. This PR also includes minor `replaceAll` compatibility fixes and `tsconfig.json` updates to support modern JavaScript features across the codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-221bf1a7-63b6-47de-9b88-0dde76343a20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-221bf1a7-63b6-47de-9b88-0dde76343a20">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>